### PR TITLE
Cperon/payload gen

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Goals / Use cases include:
 ## Installation
 * `git clone git@github.com:fastly/ftw.git`
 * `cd ftw`
+* Make sure that pip is installed `apt-get install python-pip`
 * `pip install -r requirements.txt`
 
 ## Running Tests with HTML contains and Status code checks only

--- a/ftw/ruleset.py
+++ b/ftw/ruleset.py
@@ -62,7 +62,6 @@ class Input(object):
                  version='HTTP/1.1',
                  headers={},
                  data='',
-                 status=200,
                  save_cookie=False
                  ):
         self.raw_request = raw_request
@@ -75,7 +74,6 @@ class Input(object):
         self.version = version
         self.headers = headers
         self.data = data
-        self.status = status
         self.save_cookie = save_cookie
         # Check if there is any data and do defaults
         if self.data != '':

--- a/ftw/testrunner.py
+++ b/ftw/testrunner.py
@@ -74,4 +74,4 @@ class TestRunner(object):
                                stage.output.html_contains_str)
         if stage.output.status:
             self.test_status(stage.output.status,
-                             http_ua.request_object.status)
+                             http_ua.response_object.status)

--- a/test/integration/COOKIEFIXTURE.yaml
+++ b/test/integration/COOKIEFIXTURE.yaml
@@ -21,7 +21,7 @@
               protocol: "http"
               uri: "/"
             output: 
-              status: 200
+              status: 302
               html_contains: "Set-Cookie: TS01293935="
           stage: 
             input: 
@@ -35,5 +35,5 @@
               protocol: "http"
               uri: "/"
             output: 
-              status: 200
+              status: 302
               html_contains: "Set-Cookie: TS01293935="


### PR DESCRIPTION
It looks like we need to change the cookie fixture tests, we are getting redirected (302) back from the ieee.org servers instead of the 200 specified in the test.