### PR TITLE
Set default encoding to UTF-8

### DIFF
--- a/ftw/http.py
+++ b/ftw/http.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 from __future__ import print_function
-
 import socket
 import ssl
 import string
@@ -18,7 +17,8 @@ import encodings
 from IPy import IP
 import errors
 
-
+reload(sys)
+sys.setdefaultencoding('utf8')
 
 class HttpResponse(object):
     def __init__(self, http_response, user_agent):


### PR DESCRIPTION
- Set the default encoding to UTF-8 so we can specify unicode in the
  YAML test cases.

NOTE: I am not sure if this is the best way to fix this, but it takes care of at least one test for:

https://github.com/SpiderLabs/owasp-modsecurity-crs/blob/v3.0.0-rc1/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf#L712

Which I will be committing shortly in my fork