### PR TITLE
Add ability to override headers

### DIFF
--- a/docker/TODO
+++ b/docker/TODO
@@ -1,0 +1,1 @@
+- Add logging integration to process journal

--- a/docker/docker_entry.sh
+++ b/docker/docker_entry.sh
@@ -3,9 +3,13 @@
 
 destaddr="127.0.0.1"
 ruledir=/CRS/tests
+cmd_args="--ruledir_recurse "
 
-while getopts "Dd:f:" opt; do
+while getopts "Dd:f:F" opt; do
     case $opt in
+        F)
+            cmd_args="$cmd_args --destaddr_as_host "
+            ;;
         f)
             if [ "$OPTARG" != "-" ]; then
                 ruledir=$OPTARG
@@ -16,18 +20,24 @@ while getopts "Dd:f:" opt; do
                 done
                 ruledir=$T
             fi
+            cmd_args="$cmd_args  --ruledir $ruledir "
             ;;
         D)
             set -x
             ;;
         d)
             destaddr=$OPTARG
+            cmd_args="$cmd_args --destaddr $destaddr "
             ;;
     esac
 done
 
+if [ "$ruledir" = "/CRS/tests" ]; then
+    cmd_args="$cmd_args --ruledir $ruledir "
+fi
+
 export PYTHONUNBUFFERED=1
-python /opt/ftw/tools/build_journal.py --ruledir_recurse --ruledir $ruledir  --destaddr $destaddr
+python /opt/ftw/tools/build_journal.py $cmd_args
 if [ $? -ne 0 ]; then
     echo "[errors] execution of the test fixture(s) failed"
     exit 1

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -26,5 +26,5 @@ Test individual rule files:
 If you are testing through the CDN, you can use `-F` to use the target specification has the host header.
 
 ```
-        % docker run -i ftw-test -F -d <hostname> -f - < mytest.yaml
+	% docker run -i ftw-test -F -d <hostname> -f - < mytest.yaml
 ```

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -22,3 +22,9 @@ Test individual rule files:
 ```
 	% docker run -i ftw-test -d <hostname> -f - < mytest.yaml
 ```
+
+If you are testing through the CDN, you can use `-F` to use the target specification has the host header.
+
+```
+        % docker run -i ftw-test -F -d <hostname> -f - < mytest.yaml
+```

--- a/ftw/testrunner.py
+++ b/ftw/testrunner.py
@@ -122,7 +122,7 @@ class TestRunner(object):
             if stage.output.status:
                 self.test_status(stage.output.status, status)
 
-    def run_test_build_journal(self, rule_id, test, journal_file, tablename, destaddr, callback):
+    def run_test_build_journal(self, rule_id, test, journal_file, tablename, destaddr, callback, headers = {}):
         """
         Build journal entries from a test within a specified rule_id
         Pass in the rule_id, test object, and path to journal_file 
@@ -139,6 +139,11 @@ class TestRunner(object):
                     callback(test, rule_id)
                 if destaddr is not None:
                     stage.input.dest_addr = destaddr
+                '''
+                    Merge in/override the headers that were passed in by
+                    the caller.
+                '''
+                stage.input.headers.update(headers)
                 http_ua = http.HttpUA()
                 start = datetime.datetime.now()
                 http_ua.send_request(stage.input)

--- a/tools/build_journal.py
+++ b/tools/build_journal.py
@@ -4,13 +4,13 @@ from ftw import util, testrunner
 def diag_print(test, rule_id):
     print 'Running test %s from rule file %s' % (test.test_title, rule_id)
 
-def build_journal(journal_file, ruledir, ruledir_recurse, tablename, destaddr):
+def build_journal(journal_file, ruledir, ruledir_recurse, tablename, destaddr, headers):
     util.instantiate_database(journal_file)
     rulesets = util.get_rulesets(ruledir, ruledir_recurse)
     for rule in rulesets:
         for test in rule.tests:
             runner = testrunner.TestRunner() 
-            runner.run_test_build_journal(test.ruleset_meta['name'], test, journal_file, tablename, destaddr, diag_print)
+            runner.run_test_build_journal(test.ruleset_meta['name'], test, journal_file, tablename, destaddr, diag_print, headers)
 
 def main():
     parser = argparse.ArgumentParser(description='Build FTW Journal database')
@@ -24,13 +24,18 @@ def main():
         help='Table name in journal sqlite database')
     parser.add_argument('--destaddr', default=None,
         help='Destination host for the payloads')
+    parser.add_argument('--destaddr_as_host', action='store_true',
+        help='Use destination address as the Host header')
     args = parser.parse_args()
     destaddr = args.destaddr
     journal_file = args.journal
     ruledir = args.ruledir
     ruledir_recurse = args.ruledir_recurse
     tablename = args.tablename
-    build_journal(journal_file, ruledir, ruledir_recurse, tablename, destaddr)
+    headers = {}
+    if args.destaddr_as_host:
+        headers['Host'] = destaddr = args.destaddr
+    build_journal(journal_file, ruledir, ruledir_recurse, tablename, destaddr, headers)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
- Add the ability to override headers. This is useful when testing services
  behind a CDN where the Host header is required. It should be noted that the
  headers are represented as a dictionary and get merged directly into the
  request headers. So anything can be specified, not just Host

Note: We should update run_stages to do the same thing.