### PR TITLE
Update python CVE-2017-18342

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ lazy-object-proxy==1.2.2
 py==1.4.31
 pylint==1.5.5
 pytest==2.9.1
-PyYAML==3.11
+PyYAML==4.2b1
 requests==2.20.0
 six==1.10.0
 wrapt==1.10.8


### PR DESCRIPTION
Don't require a vulnerable version of pyyaml

- Update this dep on the off chance that people are using FTW with
  untrusted YAML
- We should look into using yaml.safe_load() instead

REF: CVE-2017-18342