### PR TITLE
Shrink docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM python:2.7
+FROM python:2.7-alpine
 WORKDIR /opt/ftw
 
 ADD . .
-RUN chmod 0655 /opt/ftw/tools/build_journal.py /opt/ftw/docker/docker_entry.sh &&\
-    git clone https://github.com/SpiderLabs/OWASP-CRS-regressions.git /CRS &&\
+RUN apk add --update git py2-pip && \
+    chmod 0655 /opt/ftw/tools/build_journal.py /opt/ftw/docker/docker_entry.sh && \
+    git clone https://github.com/SpiderLabs/OWASP-CRS-regressions.git /CRS && \
     pip install -e .
 
 ENTRYPOINT [ "/opt/ftw/docker/docker_entry.sh" ]


### PR DESCRIPTION
Using the `alpine` base image reduces a lot of unnecessary overhead.

```
REPOSITORY                                                  TAG                 IMAGE ID            CREATED             SIZE
ftw-tiny                                                    latest              68b12cde94cf        23 minutes ago      140MB
ftw-big                                                     latest              06a1f390e7ae        About an hour ago   931MB
```