### PR TITLE
Add TLS support to the docker container command line

### DIFF
--- a/docker/docker_entry.sh
+++ b/docker/docker_entry.sh
@@ -5,7 +5,7 @@ destaddr="127.0.0.1"
 ruledir=/CRS/tests
 cmd_args="--ruledir_recurse "
 
-while getopts "Dd:f:F" opt; do
+while getopts "Dd:f:FP:p:" opt; do
     case $opt in
         F)
             cmd_args="$cmd_args --destaddr_as_host "
@@ -28,6 +28,14 @@ while getopts "Dd:f:F" opt; do
         d)
             destaddr=$OPTARG
             cmd_args="$cmd_args --destaddr $destaddr "
+            ;;
+        p)
+            port=$OPTARG
+            cmd_args="$cmd_args --port $port"
+            ;;
+        P)
+            proto=$OPTARG
+            cmd_args="$cmd_args --protocol $proto"
             ;;
     esac
 done

--- a/docker/docker_entry.sh
+++ b/docker/docker_entry.sh
@@ -15,8 +15,8 @@ while getopts "Dd:f:FP:p:" opt; do
                 ruledir=$OPTARG
             else
                 T=`mktemp -d -t rules.XXXXXX`
-                while IFS= read LINE; do
-                    echo "$LINE" >> $T/rules.yaml
+                while IFS= read -r LINE; do
+                    echo -E "$LINE" >> /$T/rules.yaml
                 done
                 ruledir=$T
             fi

--- a/docker/docker_entry.sh
+++ b/docker/docker_entry.sh
@@ -16,7 +16,7 @@ while getopts "Dd:f:FP:p:" opt; do
             else
                 T=`mktemp -d -t rules.XXXXXX`
                 while IFS= read -r LINE; do
-                    echo -E "$LINE" >> /$T/rules.yaml
+                    echo -E "$LINE" >> $T/rules.yaml
                 done
                 ruledir=$T
             fi

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -31,7 +31,7 @@ If you are testing through the CDN, you can use `-F` to use the target specifica
 
 ## Connecting using TLS
 
-If you wan't to connect using TLS, you need to change the port and protocol:
+If you want to connect using TLS, you need to change the port and protocol:
 
 ```
 	% docker run -i ftw-test -P https -p 443 -F -d <hostname> -f - < mytest.yaml

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -28,3 +28,11 @@ If you are testing through the CDN, you can use `-F` to use the target specifica
 ```
 	% docker run -i ftw-test -F -d <hostname> -f - < mytest.yaml
 ```
+
+## Connecting using TLS
+
+If you wan't to connect using TLS, you need to change the port and protocol:
+
+```
+	% docker run -i ftw-test -P https -p 443 -F -d <hostname> -f - < mytest.yaml
+```

--- a/ftw/http.py
+++ b/ftw/http.py
@@ -46,7 +46,15 @@ class HttpResponse(object):
         if response_headers['content-encoding'] == 'gzip':
             buf = StringIO.StringIO(response_data)
             zipbuf = gzip.GzipFile(fileobj=buf)
-            response_data = zipbuf.read()
+            try:
+                response_data = zipbuf.read()
+            except IOError:
+                raise errors.TestError(
+                    'Content encoding gzip but no compressed data',
+                    {
+                        'response_data': str(response_data),
+                        'function': 'http.HttpResponse.parse_content_encoding'
+                    })
         elif response_headers['content-encoding'] == 'deflate':
             data = StringIO.StringIO(zlib.decompress(response_data))
             response_data = data.read()

--- a/ftw/testrunner.py
+++ b/ftw/testrunner.py
@@ -122,7 +122,7 @@ class TestRunner(object):
             if stage.output.status:
                 self.test_status(stage.output.status, status)
 
-    def run_test_build_journal(self, rule_id, test, journal_file, tablename, destaddr, callback, headers = {}):
+    def run_test_build_journal(self, rule_id, test, journal_file, tablename, destaddr, callback, proto, port, headers = {}):
         """
         Build journal entries from a test within a specified rule_id
         Pass in the rule_id, test object, and path to journal_file 
@@ -139,6 +139,10 @@ class TestRunner(object):
                     callback(test, rule_id)
                 if destaddr is not None:
                     stage.input.dest_addr = destaddr
+                if proto:
+                    stage.input.protocol = proto
+                if port:
+                    stage.input.port = port
                 '''
                     Merge in/override the headers that were passed in by
                     the caller.

--- a/ftw/testrunner.py
+++ b/ftw/testrunner.py
@@ -141,7 +141,7 @@ class TestRunner(object):
                     stage.input.dest_addr = destaddr
                 if proto:
                     stage.input.protocol = proto
-                if port:
+                if port != 0:
                     stage.input.port = port
                 '''
                     Merge in/override the headers that were passed in by

--- a/test/integration/HTMLCONTAINSFIXTURE.yaml
+++ b/test/integration/HTMLCONTAINSFIXTURE.yaml
@@ -21,7 +21,7 @@
               uri: "/"
             output: 
               status: 200
-              response_contains: "established to be used for" 
+              response_contains: "for use in illustrative examples in documents" 
     - 
       test_title: "response_contains(2)"
       stages: 

--- a/test/integration/test_htmlcontains.py
+++ b/test/integration/test_htmlcontains.py
@@ -32,7 +32,7 @@ def test_search3():
     x = ruleset.Input(dest_addr="example.com",headers={"Host":"example.com"})
     http_ua = http.HttpUA()
     http_ua.send_request(x)    
-    runner.test_response(http_ua.response_object,re.compile('established to be used for'))
+    runner.test_response(http_ua.response_object,re.compile('for use in illustrative examples in documents'))
 
 # Should return a success because we found our regex
 def test_search4():   

--- a/tools/build_journal.py
+++ b/tools/build_journal.py
@@ -4,13 +4,13 @@ from ftw import util, testrunner
 def diag_print(test, rule_id):
     print 'Running test %s from rule file %s' % (test.test_title, rule_id)
 
-def build_journal(journal_file, ruledir, ruledir_recurse, tablename, destaddr, headers):
+def build_journal(journal_file, ruledir, ruledir_recurse, tablename, destaddr, headers, protocol, port):
     util.instantiate_database(journal_file)
     rulesets = util.get_rulesets(ruledir, ruledir_recurse)
     for rule in rulesets:
         for test in rule.tests:
             runner = testrunner.TestRunner() 
-            runner.run_test_build_journal(test.ruleset_meta['name'], test, journal_file, tablename, destaddr, diag_print, headers)
+            runner.run_test_build_journal(test.ruleset_meta['name'], test, journal_file, tablename, destaddr, diag_print, protocol, port, headers)
 
 def main():
     parser = argparse.ArgumentParser(description='Build FTW Journal database')
@@ -26,6 +26,10 @@ def main():
         help='Destination host for the payloads')
     parser.add_argument('--destaddr_as_host', action='store_true',
         help='Use destination address as the Host header')
+    parser.add_argument('--protocol', default=None,
+        help='Specify protocol: http or https (default http)')
+    parser.add_argument('--port', default=None,
+        help='Specify port number (default 80)')
     args = parser.parse_args()
     destaddr = args.destaddr
     journal_file = args.journal
@@ -33,9 +37,11 @@ def main():
     ruledir_recurse = args.ruledir_recurse
     tablename = args.tablename
     headers = {}
+    protocol = args.protocol
+    port = int(args.port)
     if args.destaddr_as_host:
         headers['Host'] = destaddr = args.destaddr
-    build_journal(journal_file, ruledir, ruledir_recurse, tablename, destaddr, headers)
+    build_journal(journal_file, ruledir, ruledir_recurse, tablename, destaddr, headers, protocol, port)
 
 if __name__ == '__main__':
     main()

--- a/tools/build_journal.py
+++ b/tools/build_journal.py
@@ -38,7 +38,9 @@ def main():
     tablename = args.tablename
     headers = {}
     protocol = args.protocol
-    port = int(args.port)
+    port = 0
+    if args.port:
+        port = int(args.port)
     if args.destaddr_as_host:
         headers['Host'] = destaddr = args.destaddr
     build_journal(journal_file, ruledir, ruledir_recurse, tablename, destaddr, headers, protocol, port)


### PR DESCRIPTION
- Introduce two options `--port` and `--protocol` which will allow users to override
  the YAML specification and test using TLS (or on alternate ports)
- Properly handle exceptions when we are expecting gzip'ed data but actually
  get clear text (or invalid compressed data)
- Update some unit tests which are outdated now
- Add basic documentation for the new options
- Make sure we aren't stripping escape characters from the YAML specification